### PR TITLE
feat: add setup events to setup contracts

### DIFF
--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -16,10 +16,6 @@ import 'solidity-coverage';
 const dotenvConfigPath: string = process.env.DOTENV_CONFIG_PATH || '../../.env';
 dotenvConfig({path: resolve(__dirname, dotenvConfigPath)});
 
-if (!process.env.INFURA_API_KEY) {
-  throw new Error('INFURA_API_KEY in .env not set');
-}
-
 const apiUrls: NetworkNameMapping = {
   mainnet: 'https://mainnet.infura.io/v3/',
   goerli: 'https://goerli.infura.io/v3/',
@@ -34,36 +30,20 @@ export const networks: {[index: string]: NetworkUserConfig} = {
     forking: {
       url: `${
         apiUrls[process.env.NETWORK_NAME ? process.env.NETWORK_NAME : 'mainnet']
-      }${process.env.INFURA_API_KEY}`,
+      }${process.env.ALCHEMY_API_KEY}`,
     },
-  },
-  mainnet: {
-    chainId: 1,
-    url: `${apiUrls.mainnet}${process.env.INFURA_API_KEY}`,
-  },
-  goerli: {
-    chainId: 5,
-    url: `${apiUrls.goerli}${process.env.INFURA_API_KEY}`,
   },
   polygon: {
     chainId: 137,
-    url: `${apiUrls.polygon}${process.env.INFURA_API_KEY}`,
-  },
-  polygonMumbai: {
-    chainId: 80001,
-    url: `${apiUrls.polygonMumbai}${process.env.INFURA_API_KEY}`,
-  },
-  baseGoerli: {
-    chainId: 84531,
-    url: `${apiUrls.baseGoerli}`,
-    gasPrice: 20000000000,
+    url: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
   },
 };
 
 // Uses hardhats private key if none is set. DON'T USE THIS ACCOUNT FOR DEPLOYMENTS
 const accounts = process.env.PRIVATE_KEY
   ? process.env.PRIVATE_KEY.split(',')
-  : ['0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'];
+  : // Test PK
+    ['0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'];
 
 for (const network in networks) {
   // special treatement for hardhat
@@ -82,14 +62,10 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
 });
 
 const config: HardhatUserConfig = {
-  defaultNetwork: 'hardhat',
+  defaultNetwork: 'polygon',
   etherscan: {
     apiKey: {
-      mainnet: process.env.ETHERSCAN_API_KEY || '',
-      goerli: process.env.ETHERSCAN_API_KEY || '',
       polygon: process.env.POLYGONSCAN_API_KEY || '',
-      polygonMumbai: process.env.POLYGONSCAN_API_KEY || '',
-      baseGoerli: process.env.BASESCAN_API_KEY || '',
     },
     customChains: [
       {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -60,13 +60,13 @@
     "access": "public"
   },
   "scripts": {
-    "build": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat compile",
+    "build": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat compile --show-stack-traces",
     "coverage": "hardhat coverage --solcoverjs ./.solcover.js --temp artifacts --testfiles \"test/**/*.ts\" && yarn typechain",
     "deploy": "hardhat deploy",
     "lint": "yarn lint:sol && yarn lint:ts",
     "lint:sol": "solhint \"src/**/*.sol\"",
     "lint:ts": "eslint --ignore-path ./.eslintignore --ext .js,.ts .",
-    "postinstall": "DOTENV_CONFIG_PATH=../../.env.example yarn typechain",
+    "postinstall": "DOTENV_CONFIG_PATH=../../.env yarn typechain",
     "test": "hardhat test",
     "typechain": "cross-env TS_NODE_TRANSPILE_ONLY=true hardhat typechain",
     "clean": "rimraf ./artifacts ./cache ./coverage ./types ./coverage.json && yarn typechain"

--- a/packages/contracts/src/governance/GovernancePluginsSetup.sol
+++ b/packages/contracts/src/governance/GovernancePluginsSetup.sol
@@ -13,12 +13,19 @@ import {OnlyPluginUpgraderCondition} from "../conditions/OnlyPluginUpgraderCondi
 import {MainVotingPlugin} from "./MainVotingPlugin.sol";
 import {MajorityVotingBase} from "./base/MajorityVotingBase.sol";
 
+
 /// @title GovernancePluginsSetup
 /// @dev Release 1, Build 1
 contract GovernancePluginsSetup is PluginSetup {
     address private immutable mainVotingPluginImplementation;
     address public immutable memberAccessPluginImplementation;
     address private immutable pluginSetupProcessor;
+
+    event GeoGovernancePluginsCreated(
+        address dao,
+        address mainVotingPlugin,
+        address memberAccessPlugin
+    );
 
     /// @notice Thrown when the array of helpers does not have the correct size
     error InvalidHelpers(uint256 actualLength);
@@ -146,6 +153,8 @@ contract GovernancePluginsSetup is PluginSetup {
         preparedSetupData.permissions = permissions;
         preparedSetupData.helpers = new address[](1);
         preparedSetupData.helpers[0] = _memberAccessPlugin;
+
+        emit GeoGovernancePluginsCreated(_dao, mainVotingPlugin, _memberAccessPlugin);
     }
 
     /// @inheritdoc IPluginSetup

--- a/packages/contracts/src/space/SpacePluginSetup.sol
+++ b/packages/contracts/src/space/SpacePluginSetup.sol
@@ -17,6 +17,8 @@ contract SpacePluginSetup is PluginSetup {
     address private immutable pluginImplementation;
     address private immutable pluginSetupProcessor;
 
+    event GeoSpacePluginCreated(address dao, address plugin);
+
     /// @notice Initializes the setup contract
     /// @param pluginSetupProcessorAddress The address of the PluginSetupProcessor contract deployed by Aragon on that chain
     constructor(PluginSetupProcessor pluginSetupProcessorAddress) {
@@ -88,6 +90,8 @@ contract SpacePluginSetup is PluginSetup {
         }
 
         preparedSetupData.permissions = permissions;
+
+        emit GeoSpacePluginCreated(_dao, plugin);
     }
 
     /// @inheritdoc IPluginSetup


### PR DESCRIPTION
We use the setup events to emit the plugins created by the setup contracts as well as the DAO address from a single event.